### PR TITLE
alpine: Add support for armv7 Alpine Linux

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -9,7 +9,8 @@ do
 	do
 		base_version=${PYTHON_VERSION%.*}
 		alpine_tag='latest'
-		if ( version_ge $base_version "3.7" ); then
+		# Must set DEBIAN_BUILD_TAG if want to build from Debian jessie
+		if [ -z "$DEBIAN_BUILD_TAG" ]; then
 			debian_tag='stretch'
 		else
 			debian_tag='jessie'
@@ -17,43 +18,43 @@ do
 
 		case "$ARCH" in
 			'armv6hf')
-				base_image="resin/rpi-raspbian:$debian_tag"
+				base_image="balenalib/rpi-raspbian:$debian_tag"
 				template='Dockerfile.debian.tpl'
 			;;
 			'armv7hf')
-				base_image="resin/armv7hf-debian:$debian_tag"
+				base_image="balenalib/armv7hf-debian:$debian_tag"
 				template='Dockerfile.debian.tpl'
 			;;
 			'armel')
-				base_image="resin/armel-debian:$debian_tag"
+				base_image="balenalib/armv5e-debian:$debian_tag"
 				template='Dockerfile.debian.tpl'
 			;;
 			'aarch64')
-				base_image="resin/aarch64-debian:$debian_tag"
+				base_image="balenalib/aarch64-debian:$debian_tag"
 				template='Dockerfile.debian.tpl'
 			;;
 			'i386')
-				base_image="resin/i386-debian:$debian_tag"
+				base_image="balenalib/i386-debian:$debian_tag"
 				template='Dockerfile.debian.tpl'
 			;;
 			'amd64')
-				base_image="resin/amd64-debian:$debian_tag"
+				base_image="balenalib/amd64-debian:$debian_tag"
 				template='Dockerfile.debian.tpl'
 			;;
 			'alpine-armhf')
-				base_image="resin/armv7hf-alpine:$alpine_tag"
+				base_image="balenalib/armv7hf-alpine:$alpine_tag"
 				template='Dockerfile.alpine.tpl'
 			;;
 			'alpine-i386')
-				base_image="resin/i386-alpine:$alpine_tag"
+				base_image="balenalib/i386-alpine:$alpine_tag"
 				template='Dockerfile.alpine.tpl'
 			;;
 			'alpine-amd64')
-				base_image="resin/amd64-alpine:$alpine_tag"
+				base_image="balenalib/amd64-alpine:$alpine_tag"
 				template='Dockerfile.alpine.tpl'
 			;;
 			'alpine-aarch64')
-				base_image="resin/aarch64-alpine:$alpine_tag"
+				base_image="balenalib/aarch64-alpine:$alpine_tag"
 				template='Dockerfile.alpine.tpl'
 			;;
 		esac

--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -41,8 +41,8 @@ do
 				base_image="balenalib/amd64-debian:$debian_tag"
 				template='Dockerfile.debian.tpl'
 			;;
-			'alpine-armhf')
-				base_image="balenalib/armv7hf-alpine:$alpine_tag"
+			'alpine-armv6hf')
+				base_image="balenalib/rpi-alpine:$alpine_tag"
 				template='Dockerfile.alpine.tpl'
 			;;
 			'alpine-i386')
@@ -55,6 +55,10 @@ do
 			;;
 			'alpine-aarch64')
 				base_image="balenalib/aarch64-alpine:$alpine_tag"
+				template='Dockerfile.alpine.tpl'
+			;;
+			'alpine-armv7hf')
+				base_image="balenalib/armv7hf-alpine:$alpine_tag"
 				template='Dockerfile.alpine.tpl'
 			;;
 		esac

--- a/build.sh
+++ b/build.sh
@@ -1,22 +1,35 @@
 #!/bin/bash
-set -e
-set -o pipefail
 
-gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
-gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
-gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
-gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
+gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 26DEA9D4613391EF3E25C9FF0A5B101836580288
+gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
+gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 
 
 # set env var
 PYTHON_VERSION=$1
-TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH.tar.gz
+TAR_FILE=
 BUCKET_NAME=$BUCKET_NAME
+OS=$(. /etc/os-release; printf '%s\n' "$ID")
+OS_VERSION=$(. /etc/os-release; printf '%s\n' "$VERSION_ID")
+
+if [ $OS != "alpine" ]; then
+	if [ $OS_VERSION == "8" ]; then
+		# Debian Jessie
+		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-openssl1.0.tar.gz
+	else
+		# Debian Stretch
+		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-openssl1.1.tar.gz
+	fi
+else
+	TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH.tar.gz
+fi
+
 
 mkdir -p /usr/src/python
 curl -SL "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" -o python.tar.xz
 curl -SL "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" -o python.tar.xz.asc
-gpg --verify python.tar.xz.asc
+gpg --batch --verify python.tar.xz.asc python.tar.xz
 tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz
 rm python.tar.xz*
 cd /usr/src/python


### PR DESCRIPTION
binary built from Debian Jessie will be compatible with OpenSSl1.0.x and
from Debian Stretch will be compatible with OpenSSL1.1.x

Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>