### PR TITLE
Add bluetooth dependency to support socket AF_BLUETOOTH

### DIFF
--- a/Dockerfile.alpine.tpl
+++ b/Dockerfile.alpine.tpl
@@ -2,6 +2,7 @@ FROM #{FROM}
 
 RUN set -x \
 	&& buildDeps=' \
+		bluez-dev \
 		curl \
 		gcc \
 		libbz2 \

--- a/Dockerfile.debian.tpl
+++ b/Dockerfile.debian.tpl
@@ -5,6 +5,7 @@ RUN set -x \
 		curl \
 		gcc \
 		libbz2-dev \
+		libbluetooth-dev \
 		libc6-dev \
 		libncurses-dev \
 		libreadline-dev \


### PR DESCRIPTION
Fixes https://github.com/balena-io-library/base-images/issues/641

Python should be compiled with libbluetooth, otherwise it cannot access the AF_BLUETOOTH socket. This feature is in the official images (see https://github.com/docker-library/python/pull/445) so we should support it too.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>