### PR TITLE
Add Python build variants for libffi v3.2 and v3.3

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -8,18 +8,18 @@ do
 	for PYTHON_VERSION in $PYTHON_VERSIONS
 	do
 		base_version=${PYTHON_VERSION%.*}
-		# Must set DEBIAN_BUILD_TAG if want to build from Debian Jessie (for OpenSSL 1.0)
+		# Must set DEBIAN_BUILD_TAG if want to build from Debian Buster (for libffi 3.2)
 		if [ -z "$DEBIAN_BUILD_TAG" ]; then
-			debian_tag='stretch'
+			debian_tag='buster'
 		else
-			debian_tag='jessie'
+			debian_tag='bullseye'
 		fi
 
-		# Must set ALPINE_BUILD_TAG if want to build from Alpine Linux 3.8 (for OpenSSL 1.0)
+		# Must set ALPINE_BUILD_TAG if want to build from Alpine Linux 3.11 (for libffi 3.2)
 		if [ -z "$ALPINE_BUILD_TAG" ]; then
-			alpine_tag='latest'
+			alpine_tag='3.13'
 		else
-			alpine_tag='3.8'
+			alpine_tag='3.11'
 		fi
 
 		case "$ARCH" in

--- a/build.sh
+++ b/build.sh
@@ -14,19 +14,19 @@ OS=$(. /etc/os-release; printf '%s\n' "$ID")
 OS_VERSION=$(. /etc/os-release; printf '%s\n' "$VERSION_ID")
 
 if [ $OS != "alpine" ]; then
-	if [ $OS_VERSION == "8" ]; then
-		# Debian Jessie
-		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-openssl1.0.tar.gz
+	if [ $OS_VERSION == "10" ]; then
+		# Debian Buster
+		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-libffi3.2.tar.gz
 	else
-		# Debian Stretch
-		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-openssl1.1.tar.gz
+		# Debian Bullseye
+		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-libffi3.3.tar.gz
 	fi
 else
 	OS_VERSION=$(expr match "$OS_VERSION" '\([0-9]*\.[0-9]*\)')
-	if [ $OS_VERSION == "3.8" ]; then
-		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-openssl1.0.tar.gz
+	if [ $OS_VERSION == "3.11" ]; then
+		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-libffi3.2.tar.gz
 	else
-		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-openssl1.1.tar.gz
+		TAR_FILE=Python-$PYTHON_VERSION.linux-$ARCH-libffi3.3.tar.gz
 	fi
 fi
 


### PR DESCRIPTION
Drop build variant for openssl since all supported releases are now using openssl1.1
Add build variant for libffi since some releases use 3.2 while newer ones use 3.3

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>