### PR TITLE
Revert flowzone pinning to master

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   flowzone:
     name: Flowzone
-    uses: product-os/flowzone/.github/workflows/flowzone.yml@8ea01d346097f9c0065143d2c3c7a63f490aa9cc # master
+    uses: product-os/flowzone/.github/workflows/flowzone.yml@master
     secrets: inherit


### PR DESCRIPTION
Revert flowzone workflow reference from SHA digest pin back to master branch.

The renovate-config repo now has package rules to prevent v43 from
re-pinning non-semver GitHub Actions refs to digests.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/198